### PR TITLE
Into `Sequential::and_then` and `Sequential::pipe_into`.

### DIFF
--- a/src/sequential.rs
+++ b/src/sequential.rs
@@ -1,8 +1,10 @@
 //! The [Sequential] trait and supporting types for abstract sequential processing over inputs, outputs, and explicit termination
 
 mod intosequential;
+mod pipe;
 
 pub use self::intosequential::IntoSequential;
+pub use self::pipe::Pipe;
 
 use either::Either;
 
@@ -19,4 +21,12 @@ pub trait Sequential<I>: Sized {
     ///
     /// This uses move semantics (consuming the [Sequential] and potentially producing a new one) to ensure in the case of termination, no inconsistent sequencing state remains.
     fn into_next_with(self, input: I) -> Either<(Self, Self::Output), Self::Terminal>;
+
+    /// Pipe `self` outputs into `downstream` inputs to produce a [Sequential] [Pipe] composition
+    fn pipe_into<D>(self, downstream: D) -> Pipe<Self, D>
+    where
+        D: Sequential<Self::Output>,
+    {
+        Pipe::from_parts(self, downstream)
+    }
 }

--- a/src/sequential.rs
+++ b/src/sequential.rs
@@ -1,8 +1,10 @@
 //! The [Sequential] trait and supporting types for abstract sequential processing over inputs, outputs, and explicit termination
 
+mod andthen;
 mod intosequential;
 mod pipe;
 
+pub use self::andthen::AndThen;
 pub use self::intosequential::IntoSequential;
 pub use self::pipe::{Pipe, PipeTerminal};
 
@@ -17,16 +19,25 @@ pub trait Sequential<I>: Sized {
     /// This value is produced when a sequence terminates
     type Terminal;
 
-    /// Consume the [Sequential] and an `input` to produce either a continuation (type `Self`) with an `Output` or else a `Termination` value
+    /// Consume the [Sequential] and an `input` to produce either a continuation (type `Self`) with an `Output` or else a `Termination` value and the unprocessed `input`.
     ///
     /// This uses move semantics (consuming the [Sequential] and potentially producing a new one) to ensure in the case of termination, no inconsistent sequencing state remains.
-    fn into_next_with(self, input: I) -> Either<(Self, Self::Output), Self::Terminal>;
+    fn into_next_with(self, input: I) -> Either<(Self, Self::Output), (Self::Terminal, I)>;
 
-    /// Pipe `self` outputs into `downstream` inputs to produce a [Sequential] [Pipe] composition
+    /// After completing `self`, continue with `downstream`, collecting the two terminals into a pair
+    fn and_then<D>(self, downstream: D) -> AndThen<I, Self, D>
+    where
+        D: Sequential<I, Output = Self::Output>,
+    {
+        AndThen::new(self, downstream)
+    }
+
+    /// Pipe `self` outputs into `downstream` inputs to produce a [Pipe] composition
     fn pipe_into<D>(self, downstream: D) -> Pipe<Self, D>
     where
+        I: From<Self::Output>,
         D: Sequential<Self::Output>,
     {
-        Pipe::from_parts(self, downstream)
+        Pipe(self, downstream)
     }
 }

--- a/src/sequential.rs
+++ b/src/sequential.rs
@@ -4,7 +4,7 @@ mod intosequential;
 mod pipe;
 
 pub use self::intosequential::IntoSequential;
-pub use self::pipe::Pipe;
+pub use self::pipe::{Pipe, PipeTerminal};
 
 use either::Either;
 

--- a/src/sequential/andthen.rs
+++ b/src/sequential/andthen.rs
@@ -1,0 +1,56 @@
+use crate::Sequential;
+use either::Either::{self, *};
+
+/// Compose a pair of [Sequential] values in sequence, processing all of `U` and then all of `D`
+///
+/// The uptream (type `U`) processes all inputs to produce associated outputs first, then, once terminated, downstream processes the remaining inputs until terminated.
+///
+/// The [Sequential::Terminal] value of `U` is held until the entire [AndThen] terminates with both constituent terminals.
+pub struct AndThen<I, U, D>(Inner<I, U, D>)
+where
+    U: Sequential<I>;
+
+enum Inner<I, U, D>
+where
+    U: Sequential<I>,
+{
+    UpReady(U, D),
+    DownReady(<U as Sequential<I>>::Terminal, D),
+}
+use Inner::*;
+
+impl<I, U, D> AndThen<I, U, D>
+where
+    U: Sequential<I>,
+{
+    pub(super) fn new(upstream: U, downstream: D) -> Self {
+        AndThen(UpReady(upstream, downstream))
+    }
+}
+
+impl<I, U, D, O> Sequential<I> for AndThen<I, U, D>
+where
+    U: Sequential<I, Output = O>,
+    D: Sequential<I, Output = O>,
+{
+    type Output = O;
+    type Terminal = (
+        <U as Sequential<I>>::Terminal,
+        <D as Sequential<I>>::Terminal,
+    );
+
+    fn into_next_with(self, input: I) -> Either<(Self, Self::Output), (Self::Terminal, I)> {
+        match self {
+            AndThen(UpReady(up, down)) => match up.into_next_with(input) {
+                Left((up_new, item)) => Left((AndThen(UpReady(up_new, down)), item)),
+
+                // API BUG: `into_next_with` swallows the input
+                Right((up_term, input)) => AndThen(DownReady(up_term, down)).into_next_with(input),
+            },
+            AndThen(DownReady(up_term, down)) => match down.into_next_with(input) {
+                Left((down_new, item)) => Left((AndThen(DownReady(up_term, down_new)), item)),
+                Right((down_term, input)) => Right(((up_term, down_term), input)),
+            },
+        }
+    }
+}

--- a/src/sequential/pipe.rs
+++ b/src/sequential/pipe.rs
@@ -3,9 +3,24 @@ use either::Either::{self, *};
 
 /// A composition of upstream (type `U`) and downstream (type `D`) [Sequential] types
 ///
-/// The [Sequential] impl of [Pipe] processes inputs through the upstream, passing the output to the downstream. When either member terminates, that termination value as well as the remaining state of the other member are returned in the [Pipe]'s `Terminal`.
+/// The [Sequential] impl of [Pipe] processes inputs through the upstream, passing the output to the downstream. When either member terminates, that termination value as well as the remaining state of the other member are returned in the [PipeTerminal].
 #[derive(Copy, Clone, Debug)]
 pub struct Pipe<U, D>(U, D);
+
+/// The [Sequential::Terminal] of a [Pipe] with full state
+///
+/// A [Pipe] terminates when either of the two constituent [Sequential]s terminate, which leaves the state of the other non-terminated [Sequential]. This type contains both the terminal value of one constituent and the complete state of the other constituent.
+///
+/// It is possible for callers to use this complete state with [PipeTerminal::unwrap] to continue the unterminated [Sequential]. However, many applications will ignore unterminated constituents and care only about the constituent terminal values, so they can use [PipeTerminal::child_terminal].
+pub struct PipeTerminal<I, U, D>(
+    Either<
+        (<U as Sequential<I>>::Terminal, D),
+        (U, <D as Sequential<<U as Sequential<I>>::Output>>::Terminal),
+    >,
+)
+where
+    U: Sequential<I>,
+    D: Sequential<<U as Sequential<I>>::Output>;
 
 impl<U, D> Pipe<U, D> {
     /// Construct a [Pipe] from `upstream` and `downstream` [Sequential] values
@@ -20,19 +35,44 @@ where
     D: Sequential<<U as Sequential<I>>::Output>,
 {
     type Output = <D as Sequential<<U as Sequential<I>>::Output>>::Output;
-    type Terminal = Either<
-        (<U as Sequential<I>>::Terminal, D),
-        (U, <D as Sequential<<U as Sequential<I>>::Output>>::Terminal),
-    >;
+    type Terminal = PipeTerminal<I, U, D>;
 
     fn into_next_with(self, input: I) -> Either<(Self, Self::Output), Self::Terminal> {
         let Pipe(up, down) = self;
         match up.into_next_with(input) {
             Left((next_up, item)) => match down.into_next_with(item) {
                 Left((next_down, output)) => Left((Pipe(next_up, next_down), output)),
-                Right(down_term) => Right(Right((next_up, down_term))),
+                Right(down_term) => Right(PipeTerminal(Right((next_up, down_term)))),
             },
-            Right(up_term) => Right(Left((up_term, down))),
+            Right(up_term) => Right(PipeTerminal(Left((up_term, down)))),
         }
+    }
+}
+
+impl<I, U, D> PipeTerminal<I, U, D>
+where
+    U: Sequential<I>,
+    D: Sequential<<U as Sequential<I>>::Output>,
+{
+    /// Unwrap the full state of [Pipe] termination, including one constituent's [Sequential::Terminal] value and the other constituent's full (unterminated) state
+    pub fn unwrap(
+        self,
+    ) -> Either<
+        (<U as Sequential<I>>::Terminal, D),
+        (U, <D as Sequential<<U as Sequential<I>>::Output>>::Terminal),
+    > {
+        self.0
+    }
+
+    /// Discard the pending unterminated state of one [Pipe] constituent and simply return the [Sequential::Terminal]
+    pub fn child_terminal(
+        self,
+    ) -> Either<
+        <U as Sequential<I>>::Terminal,
+        <D as Sequential<<U as Sequential<I>>::Output>>::Terminal,
+    > {
+        self.0
+            .map_left(|(up_term, _)| up_term)
+            .map_right(|(_, down_term)| down_term)
     }
 }

--- a/src/sequential/pipe.rs
+++ b/src/sequential/pipe.rs
@@ -1,0 +1,38 @@
+use crate::Sequential;
+use either::Either::{self, *};
+
+/// A composition of upstream (type `U`) and downstream (type `D`) [Sequential] types
+///
+/// The [Sequential] impl of [Pipe] processes inputs through the upstream, passing the output to the downstream. When either member terminates, that termination value as well as the remaining state of the other member are returned in the [Pipe]'s `Terminal`.
+#[derive(Copy, Clone, Debug)]
+pub struct Pipe<U, D>(U, D);
+
+impl<U, D> Pipe<U, D> {
+    /// Construct a [Pipe] from `upstream` and `downstream` [Sequential] values
+    pub fn from_parts(upstream: U, downstream: D) -> Self {
+        Pipe(upstream, downstream)
+    }
+}
+
+impl<I, U, D> Sequential<I> for Pipe<U, D>
+where
+    U: Sequential<I>,
+    D: Sequential<<U as Sequential<I>>::Output>,
+{
+    type Output = <D as Sequential<<U as Sequential<I>>::Output>>::Output;
+    type Terminal = Either<
+        (<U as Sequential<I>>::Terminal, D),
+        (U, <D as Sequential<<U as Sequential<I>>::Output>>::Terminal),
+    >;
+
+    fn into_next_with(self, input: I) -> Either<(Self, Self::Output), Self::Terminal> {
+        let Pipe(up, down) = self;
+        match up.into_next_with(input) {
+            Left((next_up, item)) => match down.into_next_with(item) {
+                Left((next_down, output)) => Left((Pipe(next_up, next_down), output)),
+                Right(down_term) => Right(Right((next_up, down_term))),
+            },
+            Right(up_term) => Right(Left((up_term, down))),
+        }
+    }
+}


### PR DESCRIPTION
This also changes `Sequential::into_next_with` to return an "unprocessed" input value upon termination.